### PR TITLE
Add a timer indicator to display when the next upload to LoRa will be

### DIFF
--- a/src/lorasoundkit/config.h
+++ b/src/lorasoundkit/config.h
@@ -24,4 +24,7 @@
 #define APPKEY "53A4419ACE4EABF7BE9E5FB0B8A16F27"
 // DEVEU is obtained from ESP board id
 
+// Some aestethical options
+#define SHOWCYCLEPROGRESS   false
+
 #endif

--- a/src/lorasoundkit/lorasoundkit.ino
+++ b/src/lorasoundkit/lorasoundkit.ino
@@ -27,6 +27,7 @@ static Oled oled;
 static char deveui[32];
 static int cycleTime = CYCLETIME;
 static bool ttnOk = false;
+long millisWhenSendToLora = -1;
 
 // Task 1 is the default ESP core 1, this one handles the LoRa TTN messages
 // Task 0 is the added ESP core 0, this one handles the audio, (read MEMS, FFT process and compose message)
@@ -107,6 +108,12 @@ void Task0code( void * pvParameters ){
     aMeasurement.update( energy);
     cMeasurement.update( energy);
     zMeasurement.update( energy);
+
+#if defined(ARDUINO_TTGO_LoRa32_V1)
+    if (SHOWCYCLEPROGRESS) {
+      oled.showProgress( millis() - millisWhenSendToLora, cycleTime * 1000);
+    }
+#endif
  
     // calculate average and compose message
     if( audioRequest) {
@@ -126,6 +133,7 @@ void Task0code( void * pvParameters ){
 #endif
 
       composeMessage( aMeasurement, cMeasurement, zMeasurement);
+      millisWhenSendToLora = millis();
 
       // reset counters etc.
       aMeasurement.reset();

--- a/src/lorasoundkit/oled.cpp
+++ b/src/lorasoundkit/oled.cpp
@@ -58,3 +58,21 @@ void Oled::showValues( Measurement& la, Measurement& lc, Measurement& lz, bool t
   display->setCursor(0, 50);  display->printf("TTN %s", (ttnOk) ? "ok" : "fail");
   display->display();
 }
+
+void Oled::showProgress( float ms, float totalms) {
+  boolean isvertical = true;
+  
+  if (isvertical) {
+    // Show a bar on the right of the screen
+    float height = ms/totalms * SCREEN_HEIGHT;
+    if (height > SCREEN_HEIGHT) height = SCREEN_HEIGHT;
+    float hcol = SCREEN_WIDTH-1;
+    display->drawLine(hcol, SCREEN_HEIGHT-1-height, hcol, SCREEN_HEIGHT-1, WHITE);
+  } else {
+    // Show a bar on the bottom of the screen
+    float width = ms/totalms * SCREEN_WIDTH;
+    float vline = SCREEN_HEIGHT-1;
+    display->drawLine(0, vline, width, vline, WHITE);
+  }
+  display->display();
+}

--- a/src/lorasoundkit/oled.h
+++ b/src/lorasoundkit/oled.h
@@ -18,6 +18,7 @@ class Oled {
     ~Oled();
     void begin( char* deveui);
     void showValues( Measurement& la, Measurement& lc, Measurement& lz, bool ttnOk);
+    void showProgress( float ms, float totalms);
 
   private:
      Adafruit_SSD1306 *display;


### PR DESCRIPTION
When using the soundkit, it would be nice to see when a cycle is send. So you could see the effect of sounds on the average (shown on the screen). And it is helpful for debugging when a new package will be sent.

This adds a configitem to show or hide a pixelwide progressbar to the right (or bottom) of the screen. It resets when a package to lora is sent.